### PR TITLE
Setup GitHub Actions

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -93,13 +93,6 @@ jobs:
             ~/.cargo/git/db
           key: ${{ runner.os }}-cargo-deps-msrv-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Setup build cache
-        uses: actions/cache@v3.0.4
-        with:
-          path: |
-            target
-          key: cargo-fmt-${{ hashFiles('**/Cargo.lock') }}-${{ steps.toolchain.outputs.rustc_hash }}
-
       - name: Check style
         uses: actions-rs/cargo@v1
         with:
@@ -152,7 +145,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: hack
-          args: clippy --feature-powerset --no-dev-deps -- -D warnings
+          args: clippy --feature-powerset --bins --tests -- -D warnings
 
 
   test:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -145,7 +145,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: hack
-          args: clippy --feature-powerset --bins --tests -- -D warnings
+          args: clippy --feature-powerset --depth 2 --bins --tests -- -D warnings
 
 
   test:
@@ -203,7 +203,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: hack
-          args: test --feature-powerset --no-dev-deps --offline
+          args: test --feature-powerset --depth 2 --offline
 
 
   coverage:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -266,3 +266,16 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           files: target/coverage/*.lcov
+
+  tests-done:
+    name: Tests done
+    needs:
+      - rustfmt
+      - clippy
+      - test
+      - coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Done"
+        run: "true"

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,278 @@
+name: Check
+
+on:
+  push:
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fetch:
+    name: Fetch Cargo dependencies
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v3
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: "1.60.0" # MSRV
+          target: x86_64-unknown-linux-musl
+          profile: minimal
+          override: true
+
+      - name: Setup Cargo cache
+        uses: actions/cache@v3.0.4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-deps-msrv-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Fetch dependencies
+        id: fetch
+        uses: actions-rs/cargo@v1
+        continue-on-error: true
+        with:
+          command: fetch
+          args: --locked
+
+      - name: Fetch dependencies (retry)
+        id: fetch-2
+        uses: actions-rs/cargo@v1
+        if: steps.fetch.outcome == 'failure'
+        continue-on-error: true
+        with:
+          command: fetch
+          args: --locked
+
+      - name: Fetch dependencies (second retry)
+        uses: actions-rs/cargo@v1
+        if: steps.fetch.outcome == 'failure' && steps.fetch-2.outcome == 'failure'
+        with:
+          command: fetch
+          args: --locked
+
+
+  rustfmt:
+    name: Check style
+    needs: [fetch]
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v3
+
+      - name: Install toolchain
+        id: toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          target: x86_64-unknown-linux-musl
+          components: rustfmt
+          profile: minimal
+          override: true
+
+      - name: Setup Cargo cache
+        uses: actions/cache@v3.0.4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-deps-msrv-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Setup build cache
+        uses: actions/cache@v3.0.4
+        with:
+          path: |
+            target
+          key: cargo-fmt-${{ hashFiles('**/Cargo.lock') }}-${{ steps.toolchain.outputs.rustc_hash }}
+
+      - name: Check style
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+
+  clippy:
+    name: Run Clippy
+    needs: [fetch]
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v3
+
+      - name: Install toolchain
+        id: toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-unknown-linux-musl
+          components: clippy
+          profile: minimal
+          override: true
+
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+
+      - name: Setup Cargo cache
+        uses: actions/cache@v3.0.4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-deps-msrv-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Setup build cache
+        uses: actions/cache@v3.0.4
+        with:
+          path: |
+            target
+          key: cargo-clippy-${{ hashFiles('**/Cargo.lock') }}-${{ steps.toolchain.outputs.rustc_hash }}
+
+      - name: Run Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: hack
+          args: clippy --feature-powerset --no-dev-deps -- -D warnings
+
+
+  test:
+    name: Run test suite with Rust ${{ matrix.toolchain }}
+    needs: [rustfmt, clippy, fetch]
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    continue-on-error: "${{ matrix.toolchain == 'beta' || matrix.toolchain == 'nightly' }}"
+
+    strategy:
+      fail-fast: false # Continue other jobs if one fails to help filling the cache
+      matrix:
+        toolchain:
+          - "1.60.0" # MSRV
+          - stable
+          - beta
+          - nightly
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v3
+
+      - name: Install toolchain
+        id: toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          target: x86_64-unknown-linux-musl
+          profile: minimal
+          override: true
+
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+
+      - name: Setup Cargo cache
+        uses: actions/cache@v3.0.4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-deps-msrv-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Setup build cache
+        uses: actions/cache@v3.0.4
+        with:
+          path: |
+            target
+          key: ${{ runner.os }}-cargo-build-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: hack
+          args: test --feature-powerset --no-dev-deps --offline
+
+
+  coverage:
+    name: Code coverage
+    needs: [rustfmt, clippy, fetch]
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v3
+
+      - name: Install toolchain
+        id: toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-unknown-linux-musl
+          override: true
+          components: llvm-tools-preview
+
+      - name: Setup Cargo cache
+        uses: actions/cache@v3.0.4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-deps-msrv-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Setup build cache
+        uses: actions/cache@v3.0.4
+        with:
+          path: |
+            target
+          key: ${{ runner.os }}-cargo-coverage-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Download grcov
+        run: |
+          mkdir -p "${HOME}/.local/bin"
+          curl -sL https://github.com/mozilla/grcov/releases/download/v0.8.10/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf - -C "${HOME}/.local/bin"
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+
+      - name: Run test suite with profiling enabled
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features --no-fail-fast --tests
+        env:
+          CARGO_INCREMENTAL: '0'
+          RUSTFLAGS: '-Cinstrument-coverage'
+          LLVM_PROFILE_FILE: "cargo-test-%p-%m.profraw"
+
+      - name: Build grcov report
+        run: |
+          mkdir -p target/coverage
+          grcov . --binary-path ./target/debug/deps/ -s . -t lcov --branch --ignore-not-existing --ignore '../*' --ignore "/*" -o target/coverage/tests.lcov
+
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v3
+        with:
+          files: target/coverage/*.lcov

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -180,9 +180,6 @@ jobs:
           profile: minimal
           override: true
 
-      - name: Install cargo-hack
-        uses: taiki-e/install-action@cargo-hack
-
       - name: Setup Cargo cache
         uses: actions/cache@v3.0.4
         with:
@@ -202,8 +199,8 @@ jobs:
       - name: Test
         uses: actions-rs/cargo@v1
         with:
-          command: hack
-          args: test --feature-powerset --depth 2 --offline
+          command: test
+          args: --all-features --offline
 
 
   coverage:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ cli = [
 
 base64url-builtins = ["dep:base64", "dep:hex"]
 crypto-digest-builtins = ["dep:digest", "dep:hex"]
-crypto-hmac-builtins = ["dep:hmac"]
+crypto-hmac-builtins = ["dep:hmac", "dep:hex"]
 crypto-md5-builtins = ["dep:md-5"]
 crypto-sha1-builtins = ["dep:sha1"]
 crypto-sha2-builtins = ["dep:sha2"]

--- a/src/builtins/impls/crypto.rs
+++ b/src/builtins/impls/crypto.rs
@@ -13,25 +13,6 @@
 // limitations under the License.
 
 #[cfg(all(
-    feature = "crypto-digest-builtins",
-    any(
-        feature = "crypto-md5-builtins",
-        feature = "crypto-sha1-builtins",
-        feature = "crypto-sha2-builtins"
-    )
-))]
-use digest::Digest;
-
-#[cfg(feature = "crypto-md5-builtins")]
-use md5::Md5;
-
-#[cfg(feature = "crypto-sha1-builtins")]
-use sha1::Sha1;
-
-#[cfg(feature = "crypto-sha2-builtins")]
-use sha2::Sha256;
-
-#[cfg(all(
     feature = "crypto-hmac-builtins",
     any(
         feature = "crypto-md5-builtins",
@@ -44,27 +25,10 @@ pub mod hmac {
     use hmac::{Hmac, Mac};
 
     #[cfg(feature = "crypto-md5-builtins")]
-    use md5::Md5;
-    #[cfg(feature = "crypto-sha1-builtins")]
-    use sha1::Sha1;
-    #[cfg(feature = "crypto-sha2-builtins")]
-    use sha2::{Sha256, Sha512};
-
-    #[cfg(feature = "crypto-md5-builtins")]
-    type HmacMd5 = Hmac<Md5>;
-
-    #[cfg(feature = "crypto-sha1-builtins")]
-    type HmacSha1 = Hmac<Sha1>;
-    #[cfg(feature = "crypto-sha2-builtins")]
-    type HmacSha256 = Hmac<Sha256>;
-    #[cfg(feature = "crypto-sha2-builtins")]
-    type HmacSha512 = Hmac<Sha512>;
-
-    #[cfg(feature = "crypto-md5-builtins")]
     /// Returns a string representing the MD5 HMAC of the input message using the input key.
     #[tracing::instrument(name = "crypto.hmac.md5", err)]
     pub fn md5(x: String, key: String) -> Result<String> {
-        let mut mac = HmacMd5::new_from_slice(key.as_bytes())?;
+        let mut mac = Hmac::<md5::Md5>::new_from_slice(key.as_bytes())?;
         mac.update(x.as_bytes());
         let res = mac.finalize();
         Ok(hex::encode(res.into_bytes()))
@@ -74,7 +38,7 @@ pub mod hmac {
     /// Returns a string representing the SHA1 HMAC of the input message using the input key.
     #[tracing::instrument(name = "crypto.hmac.sha1", err)]
     pub fn sha1(x: String, key: String) -> Result<String> {
-        let mut mac = HmacSha1::new_from_slice(key.as_bytes())?;
+        let mut mac = Hmac::<sha1::Sha1>::new_from_slice(key.as_bytes())?;
         mac.update(x.as_bytes());
         let res = mac.finalize();
         Ok(hex::encode(res.into_bytes()))
@@ -84,7 +48,7 @@ pub mod hmac {
     /// Returns a string representing the SHA256 HMAC of the input message using the input key.
     #[tracing::instrument(name = "crypto.hmac.sha256", err)]
     pub fn sha256(x: String, key: String) -> Result<String> {
-        let mut mac = HmacSha256::new_from_slice(key.as_bytes())?;
+        let mut mac = Hmac::<sha2::Sha256>::new_from_slice(key.as_bytes())?;
         mac.update(x.as_bytes());
         let res = mac.finalize();
         Ok(hex::encode(res.into_bytes()))
@@ -94,41 +58,53 @@ pub mod hmac {
     /// Returns a string representing the SHA512 HMAC of the input message using the input key.
     #[tracing::instrument(name = "crypto.hmac.sha512", err)]
     pub fn sha512(x: String, key: String) -> Result<String> {
-        let mut mac = HmacSha512::new_from_slice(key.as_bytes())?;
+        let mut mac = Hmac::<sha2::Sha512>::new_from_slice(key.as_bytes())?;
         mac.update(x.as_bytes());
         let res = mac.finalize();
         Ok(hex::encode(res.into_bytes()))
     }
 }
 
-#[cfg(all(feature = "crypto-digest-builtins", feature = "crypto-md5-builtins"))]
-/// Returns a string representing the input string hashed with the MD5 function
-#[tracing::instrument(name = "crypto.md5")]
-pub fn md5(x: String) -> String {
-    let mut hasher = Md5::new();
-    hasher.update(x.as_bytes());
-    let res = hasher.finalize();
-    hex::encode(res)
-}
+#[cfg(all(
+    feature = "crypto-digest-builtins",
+    any(
+        feature = "crypto-md5-builtins",
+        feature = "crypto-sha1-builtins",
+        feature = "crypto-sha2-builtins"
+    )
+))]
+pub mod digest {
+    use digest::Digest;
 
-#[cfg(all(feature = "crypto-digest-builtins", feature = "crypto-sha1-builtins"))]
-/// Returns a string representing the input string hashed with the SHA1 function
-#[tracing::instrument(name = "crypto.sha1")]
-pub fn sha1(x: String) -> String {
-    let mut hasher = Sha1::new();
-    hasher.update(x.as_bytes());
-    let res = hasher.finalize();
-    hex::encode(res)
-}
+    #[cfg(feature = "crypto-md5-builtins")]
+    /// Returns a string representing the input string hashed with the MD5 function
+    #[tracing::instrument(name = "crypto.md5")]
+    pub fn md5(x: String) -> String {
+        let mut hasher = md5::Md5::new();
+        hasher.update(x.as_bytes());
+        let res = hasher.finalize();
+        hex::encode(res)
+    }
 
-#[cfg(all(feature = "crypto-digest-builtins", feature = "crypto-sha2-builtins"))]
-/// Returns a string representing the input string hashed with the SHA256 function
-#[tracing::instrument(name = "crypto.sha256")]
-pub fn sha256(x: String) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(x.as_bytes());
-    let res = hasher.finalize();
-    hex::encode(res)
+    #[cfg(all(feature = "crypto-digest-builtins", feature = "crypto-sha1-builtins"))]
+    /// Returns a string representing the input string hashed with the SHA1 function
+    #[tracing::instrument(name = "crypto.sha1")]
+    pub fn sha1(x: String) -> String {
+        let mut hasher = sha1::Sha1::new();
+        hasher.update(x.as_bytes());
+        let res = hasher.finalize();
+        hex::encode(res)
+    }
+
+    #[cfg(all(feature = "crypto-digest-builtins", feature = "crypto-sha2-builtins"))]
+    /// Returns a string representing the input string hashed with the SHA256 function
+    #[tracing::instrument(name = "crypto.sha256")]
+    pub fn sha256(x: String) -> String {
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(x.as_bytes());
+        let res = hasher.finalize();
+        hex::encode(res)
+    }
 }
 
 pub mod x509 {

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -24,26 +24,26 @@ pub fn resolve(name: &str) -> Result<Box<dyn Builtin>> {
         #[cfg(feature = "base64url-builtins")]
         "base64url.encode_no_pad" => Ok(self::impls::base64url::encode_no_pad.wrap()),
 
-        #[cfg(feature = "crypto-md5-builtins")]
+        #[cfg(all(feature = "crypto-md5-builtins", feature = "crypto-hmac-builtins"))]
         "crypto.hmac.md5" => Ok(self::impls::crypto::hmac::md5.wrap()),
 
-        #[cfg(feature = "crypto-sha1-builtins")]
+        #[cfg(all(feature = "crypto-sha1-builtins", feature = "crypto-hmac-builtins"))]
         "crypto.hmac.sha1" => Ok(self::impls::crypto::hmac::sha1.wrap()),
 
-        #[cfg(feature = "crypto-sha2-builtins")]
+        #[cfg(all(feature = "crypto-sha2-builtins", feature = "crypto-hmac-builtins"))]
         "crypto.hmac.sha256" => Ok(self::impls::crypto::hmac::sha256.wrap()),
 
-        #[cfg(feature = "crypto-sha2-builtins")]
+        #[cfg(all(feature = "crypto-sha2-builtins", feature = "crypto-hmac-builtins"))]
         "crypto.hmac.sha512" => Ok(self::impls::crypto::hmac::sha512.wrap()),
 
-        #[cfg(feature = "crypto-md5-builtins")]
-        "crypto.md5" => Ok(self::impls::crypto::md5.wrap()),
+        #[cfg(all(feature = "crypto-md5-builtins", feature = "crypto-digest-builtins"))]
+        "crypto.md5" => Ok(self::impls::crypto::digest::md5.wrap()),
 
-        #[cfg(feature = "crypto-sha1-builtins")]
-        "crypto.sha1" => Ok(self::impls::crypto::sha1.wrap()),
+        #[cfg(all(feature = "crypto-sha1-builtins", feature = "crypto-digest-builtins"))]
+        "crypto.sha1" => Ok(self::impls::crypto::digest::sha1.wrap()),
 
-        #[cfg(feature = "crypto-sha2-builtins")]
-        "crypto.sha256" => Ok(self::impls::crypto::sha256.wrap()),
+        #[cfg(all(feature = "crypto-sha2-builtins", feature = "crypto-digest-builtins"))]
+        "crypto.sha256" => Ok(self::impls::crypto::digest::sha256.wrap()),
 
         "crypto.x509.parse_and_verify_certificates" => {
             Ok(self::impls::crypto::x509::parse_and_verify_certificates.wrap())


### PR DESCRIPTION
This sets up GitHub Actions to run the tests and clippy lints.
It leverages `cargo-hack` to run clippy lints with many features combinations, to check that most combinations compile.