### PR TITLE
Add a .tar.gz bundle loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
+name = "async-compression"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345fd392ab01f746c717b1357165b76f0b67a60192007b234058c9045fdcf695"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,6 +152,18 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
+name = "camino"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "869119e97797867fd90f5e22af7d0bd274bd4635ebb9eb68c04f3f513ae6c412"
 
 [[package]]
 name = "cc"
@@ -470,6 +495,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0408e2626025178a6a7f7ffc05a25bc47103229f19c113755de7bf63816290c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+
+[[package]]
+name = "futures-util"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,9 +838,12 @@ name = "opa-wasm"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-compression",
  "base64",
+ "camino",
  "clap",
  "digest 0.10.3",
+ "futures-util",
  "hex",
  "hmac",
  "json-patch",
@@ -769,6 +856,7 @@ dependencies = [
  "sprintf",
  "thiserror",
  "tokio",
+ "tokio-tar",
  "tracing",
  "tracing-forest",
  "tracing-subscriber",
@@ -798,6 +886,12 @@ name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
@@ -1094,6 +1188,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+
+[[package]]
 name = "slice-group-by"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1196,6 +1296,8 @@ version = "1.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
 dependencies = [
+ "bytes",
+ "memchr",
  "num_cpus",
  "once_cell",
  "pin-project-lite",
@@ -1211,6 +1313,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tar"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a50188549787c32c1c3d9c8c71ad7e003ccf2f102489c5a96e385c84760477f4"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "redox_syscall",
+ "tokio",
+ "tokio-stream",
+ "xattr",
 ]
 
 [[package]]
@@ -1594,6 +1722,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,13 @@ tokio = { version = "1.19.2", features = ["sync", "macros"] }
 tracing = "0.1.35"
 wasmtime = { version = "0.38.1", default-features = false, features = ["async"] }
 
+# Loader
+tokio-tar = { version = "0.3.0", optional = true }
+async-compression = { version = "0.3.14", optional = true, features = ["tokio", "gzip"] }
+futures-util = { version = "0.3.21", optional = true }
+
 # CLI
+camino = { version = "1.0.9", optional = true }
 clap = { version = "3.2.6", features = ["derive"], optional = true }
 tracing-forest = { version = "0.1.4", optional = true }
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"], optional = true }
@@ -43,7 +49,17 @@ version = "0.38.1"
 [features]
 default = ["all-builtins"]
 
+loader = [
+  "dep:tokio-tar",
+  "dep:async-compression",
+  "dep:futures-util",
+  "tokio/fs",
+  "tokio/io-util",
+]
+
 cli = [
+  "loader",
+  "dep:camino",
   "dep:clap",
   "dep:tracing-forest",
   "dep:tracing-subscriber",

--- a/README.md
+++ b/README.md
@@ -21,16 +21,17 @@ opa-wasm
 Evaluates OPA policies compiled as WASM modules
 
 USAGE:
-    opa-eval [OPTIONS] --module <MODULE> --entrypoint <ENTRYPOINT>
+    opa-eval [OPTIONS] --entrypoint <ENTRYPOINT> <--module <MODULE>|--bundle <BUNDLE>>
 
 OPTIONS:
-    -d, --data <JSON>                JSON literal to use as data
-        --data-path <PATH>           Path to a JSON file to load as data
-    -e, --entrypoint <ENTRYPOINT>    Entrypoint to use
-    -h, --help                       Print help information
-    -i, --input <JSON>               JSON literal to use as input
-        --input-path <PATH>          Path to a JSON file to load as data
     -m, --module <MODULE>            Path to the WASM module
+    -b, --bundle <BUNDLE>            Path to the OPA bundle
+    -e, --entrypoint <ENTRYPOINT>    Entrypoint to use
+    -d, --data <JSON>                JSON literal to use as data
+    -D, --data-path <PATH>           Path to a JSON file to load as data
+    -i, --input <JSON>               JSON literal to use as input
+    -I, --input-path <PATH>          Path to a JSON file to load as data
+    -h, --help                       Print help information
 ```
 
 ## As a library

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,9 +17,13 @@
 
 pub mod builtins;
 mod funcs;
+#[cfg(feature = "loader")]
+mod loader;
 mod policy;
 mod types;
 
+#[cfg(feature = "loader")]
+pub use self::loader::{load_bundle, read_bundle};
 pub use self::{
     policy::{Policy, Runtime},
     types::AbiVersion,

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -1,0 +1,64 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::Path;
+
+use anyhow::Context;
+use async_compression::tokio::bufread::GzipDecoder;
+use futures_util::TryStreamExt;
+use tokio::io::{AsyncBufRead, AsyncReadExt, BufReader};
+use tokio_tar::Archive;
+use tracing::{info_span, Instrument};
+
+/// Read an OPA compiled bundle from disk
+#[tracing::instrument(err)]
+pub async fn read_bundle(path: impl AsRef<Path> + std::fmt::Debug) -> anyhow::Result<Vec<u8>> {
+    let file = tokio::fs::File::open(path).await?;
+    let reader = BufReader::new(file);
+    load_bundle(reader).await
+}
+
+/// Load an OPA compiled bundle
+#[tracing::instrument(skip_all, err)]
+pub async fn load_bundle(
+    reader: impl AsyncBufRead + Unpin + Send + Sync,
+) -> anyhow::Result<Vec<u8>> {
+    // Wrap the reader in a gzip decoder, then in a tar unarchiver
+    let reader = GzipDecoder::new(reader);
+    let mut archive = Archive::new(reader);
+
+    // Go through the archive entries to find the /policy.wasm one
+    let entries = archive.entries()?;
+    let mut entry = entries
+        .try_filter(|e| {
+            std::future::ready(
+                e.path()
+                    .map(|p| p.as_os_str() == "/policy.wasm")
+                    .unwrap_or(false),
+            )
+        })
+        .try_next()
+        .instrument(info_span!("find_bundle_entry"))
+        .await?
+        .context("could not find WASM policy in tar archive")?;
+
+    // Once we found it, read it completely to a buffer
+    let mut buf = Vec::new();
+    entry
+        .read_to_end(&mut buf)
+        .instrument(info_span!("read_module"))
+        .await?;
+
+    Ok(buf)
+}


### PR DESCRIPTION
This adds an (optional) .tar.gz bundle loader, exposed in the library behind the `loader` feature. It's a fully async one, and only loads what's needed from the tar.

It also adds that capability to the CLI, by adding a `--bundle` flag. I also went ahead and changed the `PathBuf`s in the CLI to camino's `Utf8PathBuf`, because it's a mess to have to deal with OsStrings, and not worth it.

@jondot: You might want to take a look to use that in the integration tests