### PR TITLE
Add an evaluation context for cache and random

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,6 +958,7 @@ dependencies = [
  "json-patch",
  "md-5",
  "parse-size",
+ "rand",
  "rstest",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ hex = { version = "0.4.3", optional = true }
 hmac = { version = "0.12.1", optional = true }
 json-patch = { version = "0.2.6", optional = true }
 md-5 = { version = "0.10.1", optional = true }
+rand = { version = "0.8.5", optional = true }
 semver = { version = "1.0.12", optional = true }
 sha1 = { version = "0.10.1", optional = true }
 sha2 = { version = "0.10.2", optional = true }
@@ -73,6 +74,8 @@ cli = [
   "wasmtime/memory-init-cow",
 ]
 
+rng = ["dep:rand"]
+
 base64url-builtins = ["dep:base64", "dep:hex"]
 crypto-digest-builtins = ["dep:digest", "dep:hex"]
 crypto-hmac-builtins = ["dep:hmac", "dep:hex"]
@@ -84,6 +87,7 @@ semver-builtins = ["dep:semver"]
 sprintf-builtins = ["dep:sprintf"]
 json-builtins = ["dep:json-patch"]
 units-builtins = ["dep:parse-size"]
+rand-builtins = ["rng"]
 
 all-crypto-builtins = [
   "crypto-digest-builtins",
@@ -98,6 +102,7 @@ all-builtins = [
   "base64url-builtins",
   "hex-builtins",
   "json-builtins",
+  "rand-builtins",
   "semver-builtins",
   "sprintf-builtins",
   "units-builtins",

--- a/src/builtins/impls/mod.rs
+++ b/src/builtins/impls/mod.rs
@@ -34,6 +34,7 @@ pub mod json;
 pub mod net;
 pub mod object;
 pub mod opa;
+#[cfg(feature = "rng")]
 pub mod rand;
 pub mod regex;
 pub mod rego;

--- a/src/builtins/impls/rand.rs
+++ b/src/builtins/impls/rand.rs
@@ -14,7 +14,7 @@
 
 //! Builtins used to generate pseudo-random values
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use rand::Rng;
 
 use crate::EvaluationContext;
@@ -24,6 +24,14 @@ use crate::EvaluationContext;
 /// will be consistent throughout a query evaluation.
 #[tracing::instrument(name = "rand.intn", skip(ctx), err)]
 pub fn intn<C: EvaluationContext>(ctx: &mut C, str: String, n: i64) -> Result<i64> {
+    if n == 0 {
+        return Ok(0);
+    }
+
+    if n < 0 {
+        bail!("rand.intn: n must be a positive integer")
+    }
+
     let cache_key = ("rand", str, n);
     if let Some(v) = ctx.cache_get(&cache_key)? {
         return Ok(v);

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -108,7 +108,10 @@ pub fn resolve<C: EvaluationContext>(name: &str) -> Result<Box<dyn Builtin<C>>> 
         "net.lookup_ip_addr" => Ok(self::impls::net::lookup_ip_addr.wrap()),
         "object.union_n" => Ok(self::impls::object::union_n.wrap()),
         "opa.runtime" => Ok(self::impls::opa::runtime.wrap()),
+
+        #[cfg(feature = "rng")]
         "rand.intn" => Ok(self::impls::rand::intn.wrap()),
+
         "regex.find_n" => Ok(self::impls::regex::find_n.wrap()),
         "regex.globs_match" => Ok(self::impls::regex::globs_match.wrap()),
         "regex.split" => Ok(self::impls::regex::split.wrap()),

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -17,6 +17,7 @@
 use anyhow::{bail, Result};
 
 use self::traits::{Builtin, BuiltinFunc};
+use crate::EvaluationContext;
 
 pub mod impls;
 pub mod traits;
@@ -27,7 +28,7 @@ pub mod traits;
 ///
 /// Returns an error if the builtin is not known
 #[allow(clippy::too_many_lines)]
-pub fn resolve(name: &str) -> Result<Box<dyn Builtin>> {
+pub fn resolve<C: EvaluationContext>(name: &str) -> Result<Box<dyn Builtin<C>>> {
     match name {
         #[cfg(feature = "base64url-builtins")]
         "base64url.encode_no_pad" => Ok(self::impls::base64url::encode_no_pad.wrap()),

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,114 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(clippy::module_name_repetitions)]
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use serde::{de::DeserializeOwned, Serialize};
+
+/// Context passed through builtin evaluation
+pub trait EvaluationContext: Send + 'static {
+    /// The type of random number generator used by this context
+    #[cfg(feature = "rng")]
+    type Rng: rand::Rng;
+
+    /// Get a [`rand::Rng`]
+    #[cfg(feature = "rng")]
+    fn get_rng(&mut self) -> Self::Rng;
+
+    /// Get a value from the evaluation cache
+    ///
+    /// # Errors
+    ///
+    /// If the key failed to serialize, or the value failed to deserialize
+    fn cache_get<K: Serialize, C: DeserializeOwned>(&mut self, key: &K) -> Result<Option<C>>;
+
+    /// Push a value to the evaluation cache
+    ///
+    /// # Errors
+    ///
+    /// If the key or the value failed to serialize
+    fn cache_set<K: Serialize, C: Serialize>(&mut self, key: &K, content: &C) -> Result<()>;
+}
+
+/// The default evaluation context implementation
+#[derive(Default)]
+pub struct DefaultContext {
+    cache: HashMap<String, serde_json::Value>,
+}
+
+impl EvaluationContext for DefaultContext {
+    #[cfg(feature = "rng")]
+    type Rng = rand::rngs::ThreadRng;
+
+    #[cfg(feature = "rng")]
+    fn get_rng(&mut self) -> Self::Rng {
+        rand::thread_rng()
+    }
+
+    fn cache_get<K: Serialize, C: DeserializeOwned>(&mut self, key: &K) -> Result<Option<C>> {
+        let key = serde_json::to_string(&key)?;
+        let value = if let Some(val) = self.cache.get(&key) {
+            val
+        } else {
+            return Ok(None);
+        };
+
+        let value = serde_json::from_value(value.clone())?;
+        Ok(value)
+    }
+
+    fn cache_set<K: Serialize, C: Serialize>(&mut self, key: &K, content: &C) -> Result<()> {
+        let key = serde_json::to_string(key)?;
+        let content = serde_json::to_value(content)?;
+        self.cache.insert(key, content);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use anyhow::Result;
+    use serde::{de::DeserializeOwned, Serialize};
+
+    use crate::{DefaultContext, EvaluationContext};
+
+    /// A context used in tests
+    #[derive(Default)]
+    pub struct TestContext {
+        inner: DefaultContext,
+    }
+
+    impl EvaluationContext for TestContext {
+        #[cfg(feature = "rng")]
+        type Rng = rand::rngs::StdRng;
+
+        #[cfg(feature = "rng")]
+        fn get_rng(&mut self) -> Self::Rng {
+            use rand::SeedableRng;
+
+            rand::rngs::StdRng::seed_from_u64(0)
+        }
+
+        fn cache_get<K: Serialize, C: DeserializeOwned>(&mut self, key: &K) -> Result<Option<C>> {
+            self.inner.cache_get(key)
+        }
+
+        fn cache_set<K: Serialize, C: Serialize>(&mut self, key: &K, content: &C) -> Result<()> {
+            self.inner.cache_set(key, content)
+        }
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -89,6 +89,8 @@ pub mod tests {
     #[derive(Default)]
     pub struct TestContext {
         inner: DefaultContext,
+
+        #[cfg(feature = "rng")]
         seed: u64,
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -79,8 +79,7 @@ impl EvaluationContext for DefaultContext {
     }
 }
 
-#[cfg(test)]
-pub(crate) mod tests {
+pub mod tests {
     use anyhow::Result;
     use serde::{de::DeserializeOwned, Serialize};
 
@@ -90,6 +89,7 @@ pub(crate) mod tests {
     #[derive(Default)]
     pub struct TestContext {
         inner: DefaultContext,
+        seed: u64,
     }
 
     impl EvaluationContext for TestContext {
@@ -100,7 +100,7 @@ pub(crate) mod tests {
         fn get_rng(&mut self) -> Self::Rng {
             use rand::SeedableRng;
 
-            rand::rngs::StdRng::seed_from_u64(0)
+            rand::rngs::StdRng::seed_from_u64(self.seed)
         }
 
         fn cache_get<K: Serialize, C: DeserializeOwned>(&mut self, key: &K) -> Result<Option<C>> {

--- a/src/context.rs
+++ b/src/context.rs
@@ -29,6 +29,9 @@ pub trait EvaluationContext: Send + 'static {
     #[cfg(feature = "rng")]
     fn get_rng(&mut self) -> Self::Rng;
 
+    /// Notify the context on evaluation start, so it can clean itself up
+    fn evaluation_start(&mut self);
+
     /// Get a value from the evaluation cache
     ///
     /// # Errors
@@ -57,6 +60,11 @@ impl EvaluationContext for DefaultContext {
     #[cfg(feature = "rng")]
     fn get_rng(&mut self) -> Self::Rng {
         rand::thread_rng()
+    }
+
+    fn evaluation_start(&mut self) {
+        // Clear the cache
+        self.cache = HashMap::new();
     }
 
     fn cache_get<K: Serialize, C: DeserializeOwned>(&mut self, key: &K) -> Result<Option<C>> {
@@ -97,6 +105,10 @@ pub mod tests {
     impl EvaluationContext for TestContext {
         #[cfg(feature = "rng")]
         type Rng = rand::rngs::StdRng;
+
+        fn evaluation_start(&mut self) {
+            self.inner.evaluation_start();
+        }
 
         #[cfg(feature = "rng")]
         fn get_rng(&mut self) -> Self::Rng {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 #![deny(missing_docs, clippy::pedantic)]
 
 pub mod builtins;
+mod context;
 mod funcs;
 #[cfg(feature = "loader")]
 mod loader;
@@ -25,6 +26,7 @@ mod types;
 #[cfg(feature = "loader")]
 pub use self::loader::{load_bundle, read_bundle};
 pub use self::{
+    context::{DefaultContext, EvaluationContext},
     policy::{Policy, Runtime},
     types::AbiVersion,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ mod types;
 #[cfg(feature = "loader")]
 pub use self::loader::{load_bundle, read_bundle};
 pub use self::{
-    context::{DefaultContext, EvaluationContext},
+    context::{tests::TestContext, DefaultContext, EvaluationContext},
     policy::{Policy, Runtime},
     types::AbiVersion,
 };

--- a/tests/infra-fixtures/test-rand.rego
+++ b/tests/infra-fixtures/test-rand.rego
@@ -1,0 +1,20 @@
+#  Copyright 2022 The Matrix.org Foundation C.I.C.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+package test
+
+zero := rand.intn("zero", 0)
+first := rand.intn("first", 10)
+second := rand.intn("second", 100)
+cache := rand.intn("second", 100)

--- a/tests/smoke_test.rs
+++ b/tests/smoke_test.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 
 use anyhow::Result as AnyResult;
 use insta::assert_yaml_snapshot;
-use opa_wasm::{read_bundle, Runtime};
+use opa_wasm::{read_bundle, Runtime, TestContext};
 use serde_json::json;
 use wasmtime::{Config, Engine, Module, Store};
 
@@ -57,8 +57,10 @@ async fn eval_policy(
     // Create a store which will hold the module instance
     let mut store = Store::new(&engine, ());
 
+    let ctx = TestContext::default();
+
     // Instantiate the module
-    let runtime = Runtime::new(&mut store, &module).await?;
+    let runtime = Runtime::new_with_evaluation_context(&mut store, &module, ctx).await?;
 
     let policy = runtime.without_data(&mut store).await?;
 
@@ -116,6 +118,7 @@ integration_test!(
 integration_test!(test_loader_true, "test-loader", input = "test-loader.true");
 integration_test!(test_loader_empty, "test-loader");
 integration_test!(test_units, "test-units");
+integration_test!(test_rand, "test-rand");
 
 /*
 #[tokio::test]

--- a/tests/snapshots/smoke_test__rand.snap
+++ b/tests/snapshots/smoke_test__rand.snap
@@ -1,0 +1,10 @@
+---
+source: tests/smoke_test.rs
+expression: "test_policy(\"test-rand\", None).await.expect(\"error in test suite\")"
+---
+- result:
+    cache: 73
+    first: 7
+    second: 73
+    zero: 0
+


### PR DESCRIPTION
This adds an 'evaluation context' where builtins can access a cache and a RNG. This is a generic/a trait, so we can have different implementation, which is especially important in tests, where we want to seed the RNG.

Still a draft because the cache/context is not yet reset through multiple evaluation

@jondot Let met know if this API makes sense