### PR TITLE
implement units

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,6 +1005,7 @@ dependencies = [
  "insta",
  "json-patch",
  "md-5",
+ "parse-size",
  "rstest",
  "semver",
  "serde",
@@ -1038,6 +1039,12 @@ name = "os_str_bytes"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+
+[[package]]
+name = "parse-size"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "944553dd59c802559559161f9816429058b869003836120e262e8caec061b7ae"
 
 [[package]]
 name = "paste"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ semver = { version = "1.0.12", optional = true }
 sha1 = { version = "0.10.1", optional = true }
 sha2 = { version = "0.10.2", optional = true }
 sprintf = { version = "0.1.2", optional = true }
+parse-size = { version = "1.0.0", features=["std"], optional = true }
 
 [dev-dependencies.tokio]
 version = "1.19.2"
@@ -84,6 +85,7 @@ hex-builtins = ["dep:hex"]
 semver-builtins = ["dep:semver"]
 sprintf-builtins = ["dep:sprintf"]
 json-builtins = ["dep:json-patch"]
+units-builtins = ["dep:parse-size"]
 
 all-crypto-builtins = [
   "crypto-digest-builtins",
@@ -100,6 +102,7 @@ all-builtins = [
   "json-builtins",
   "semver-builtins",
   "sprintf-builtins",
+  "units-builtins"
 ]
 
 [[test]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ all-builtins = [
   "json-builtins",
   "semver-builtins",
   "sprintf-builtins",
-  "units-builtins"
+  "units-builtins",
 ]
 
 [[test]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ semver = { version = "1.0.12", optional = true }
 sha1 = { version = "0.10.1", optional = true }
 sha2 = { version = "0.10.2", optional = true }
 sprintf = { version = "0.1.2", optional = true }
-parse-size = { version = "1.0.0", features=["std"], optional = true }
+parse-size = { version = "1.0.0", features = ["std"], optional = true }
 
 [dev-dependencies.tokio]
 version = "1.19.2"

--- a/src/builtins/impls/mod.rs
+++ b/src/builtins/impls/mod.rs
@@ -40,6 +40,7 @@ pub mod rego;
 #[cfg(feature = "semver-builtins")]
 pub mod semver;
 pub mod time;
+#[cfg(feature = "units-builtins")]
 pub mod units;
 pub mod urlquery;
 pub mod uuid;

--- a/src/builtins/impls/units.rs
+++ b/src/builtins/impls/units.rs
@@ -14,7 +14,8 @@
 
 //! Builtins to parse and convert units
 
-use anyhow::{bail, Result};
+use anyhow::Result;
+use parse_size::Config;
 
 /// Converts strings like "10G", "5K", "4M", "1500m" and the like into a number.
 /// This number can be a non-integer, such as 1.5, 0.22, etc. Supports standard
@@ -24,9 +25,19 @@ use anyhow::{bail, Result};
 ///
 /// Note that 'm' and 'M' are case-sensitive, to allow distinguishing between
 /// "milli" and "mega" units respectively. Other units are case-insensitive.
+#[allow(clippy::cast_precision_loss)]
 #[tracing::instrument(name = "units.parse", err)]
-pub fn parse(x: String) -> Result<i64> {
-    bail!("not implemented");
+pub fn parse(x: String) -> Result<serde_json::Value> {
+    // we're giving back serde_json::Value because per Go OPA, `parse`
+    // returns usize _or_ float, and this allows to return multiple types.
+    let p = Config::new().with_decimal();
+    if let [init @ .., prefix] = x.as_bytes() {
+        // edge case here, when 'm' is lowercase that's mili
+        if b'm'.eq(prefix) {
+            return Ok(serde_json::to_value(p.parse_size(init)? as f64 * 0.001)?);
+        }
+    }
+    Ok(serde_json::to_value(p.parse_size(x.as_str())?)?)
 }
 
 /// Converts strings like "10GB", "5K", "4mb" into an integer number of bytes.
@@ -35,6 +46,6 @@ pub fn parse(x: String) -> Result<i64> {
 /// units. The bytes symbol (b/B) in the unit is optional and omitting it wil
 /// give the same result (e.g. Mi and MiB).
 #[tracing::instrument(name = "units.parse_bytes", err)]
-pub fn parse_bytes(x: String) -> Result<i64> {
-    bail!("not implemented");
+pub fn parse_bytes(x: String) -> Result<u64> {
+    Ok(Config::new().with_decimal().parse_size(x.as_str())?)
 }

--- a/src/builtins/impls/units.rs
+++ b/src/builtins/impls/units.rs
@@ -46,5 +46,5 @@ pub fn parse(x: String) -> Result<serde_json::Value> {
 /// give the same result (e.g. Mi and MiB).
 #[tracing::instrument(name = "units.parse_bytes", err)]
 pub fn parse_bytes(x: String) -> Result<u64> {
-    Ok(Config::new().with_decimal().parse_size(x.as_str())?)
+    Config::new().with_decimal().parse_size(x.as_str()).context("could not parse value")
 }

--- a/src/builtins/impls/units.rs
+++ b/src/builtins/impls/units.rs
@@ -31,9 +31,8 @@ pub fn parse(x: String) -> Result<serde_json::Value> {
     // we're giving back serde_json::Value because per Go OPA, `parse`
     // returns usize _or_ float, and this allows to return multiple types.
     let p = Config::new().with_decimal();
-    if let [init @ .., prefix] = x.as_bytes() {
-        // edge case here, when 'm' is lowercase that's mili
-        if b'm'.eq(prefix) {
+    // edge case here, when 'm' is lowercase that's mili
+    if let [init @ .., b'm'] = x.as_bytes() {
             return Ok(serde_json::to_value(p.parse_size(init)? as f64 * 0.001)?);
         }
     }

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -132,8 +132,13 @@ pub fn resolve(name: &str) -> Result<Box<dyn Builtin>> {
         "time.parse_rfc3339_ns" => Ok(self::impls::time::parse_rfc3339_ns.wrap()),
         "time.weekday" => Ok(self::impls::time::weekday.wrap()),
         "trace" => Ok(self::impls::trace.wrap()),
+
+        #[cfg(feature = "units-builtins")]
         "units.parse" => Ok(self::impls::units::parse.wrap()),
+
+        #[cfg(feature = "units-builtins")]
         "units.parse_bytes" => Ok(self::impls::units::parse_bytes.wrap()),
+
         "urlquery.decode" => Ok(self::impls::urlquery::decode.wrap()),
         "urlquery.decode_object" => Ok(self::impls::urlquery::decode_object.wrap()),
         "urlquery.encode" => Ok(self::impls::urlquery::encode.wrap()),

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -26,6 +26,7 @@ pub mod traits;
 /// # Errors
 ///
 /// Returns an error if the builtin is not known
+#[allow(clippy::too_many_lines)]
 pub fn resolve(name: &str) -> Result<Box<dyn Builtin>> {
     match name {
         #[cfg(feature = "base64url-builtins")]

--- a/tests/infra-fixtures/test-units.rego
+++ b/tests/infra-fixtures/test-units.rego
@@ -1,0 +1,25 @@
+package test
+
+v_bytes := units.parse_bytes("1K")
+
+v_bytes_nounit := units.parse_bytes("100")
+
+v_bytes_mib := units.parse_bytes("1MiB")
+
+v_bytes_lower := units.parse_bytes("200m")
+
+v_bytes_frac := units.parse_bytes("1.5mib")
+
+v_bytes_zero := units.parse_bytes("0M")
+
+v_decimal := units.parse("1K")
+
+v_decimal_nounit := units.parse("100")
+
+v_decimal_lower := units.parse("1mb")
+
+v_decimal_mili := units.parse("200m")
+
+v_decimal_frac := units.parse("1.5M")
+
+v_decimal_zero := units.parse("0M")

--- a/tests/smoke_test.rs
+++ b/tests/smoke_test.rs
@@ -114,6 +114,7 @@ integration_test!(
 );
 integration_test!(test_loader_true, "test-loader", input = "test-loader.true");
 integration_test!(test_loader_empty, "test-loader");
+integration_test!(test_units, "test-units");
 
 /*
 #[tokio::test]

--- a/tests/snapshots/smoke_test__units.snap
+++ b/tests/snapshots/smoke_test__units.snap
@@ -1,0 +1,18 @@
+---
+source: tests/smoke_test.rs
+expression: "test_policy(\"test-units\", None).await.expect(\"error in test suite\")"
+---
+- result:
+    v_bytes: 1000
+    v_bytes_frac: 1572864
+    v_bytes_lower: 200000000
+    v_bytes_mib: 1048576
+    v_bytes_nounit: 100
+    v_bytes_zero: 0
+    v_decimal: 1000
+    v_decimal_frac: 1500000
+    v_decimal_lower: 1000000
+    v_decimal_mili: 0.2
+    v_decimal_nounit: 100
+    v_decimal_zero: 0
+


### PR DESCRIPTION
Implementing units, largely covered by existing Rust crate that does the parsing, with the exception of the `m` (millis) case.

Go OPA: https://www.openpolicyagent.org/docs/latest/policy-reference/#units
