### PR TITLE
Fix Clippy warnings introduced in Rust 1.66.0

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -44,8 +44,8 @@ jobs:
 
       - name: Install toolchain
         run: |
-          rustup toolchain install stable
-          rustup default stable
+          rustup toolchain install 1.66.0
+          rustup default 1.66.0
           rustup component add clippy
 
       - name: Setup Rust cache

--- a/src/bin/opa-eval.rs
+++ b/src/bin/opa-eval.rs
@@ -136,7 +136,7 @@ async fn main() -> Result<()> {
         .instrument(tracing::info_span!("evaluate"))
         .await?;
 
-    println!("{}", res);
+    println!("{res}");
 
     Ok(())
 }

--- a/src/bin/simple.rs
+++ b/src/bin/simple.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![deny(clippy::pedantic)]
+
 use std::collections::HashMap;
 
 use anyhow::Result;
@@ -44,7 +46,7 @@ async fn main() -> Result<()> {
     // Evaluate the policy
     let res: serde_json::Value = policy.evaluate(&mut store, "hello/world", &input).await?;
 
-    println!("{}", res);
+    println!("{res}");
 
     Ok(())
 }

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -27,9 +27,9 @@ where
 {
     caller
         .get_export(name)
-        .with_context(|| format!("could not find export {:?}", name))?
+        .with_context(|| format!("could not find export {name:?}"))?
         .into_func()
-        .with_context(|| format!("export {:?} is not a function", name))?
+        .with_context(|| format!("export {name:?} is not a function"))?
         .typed(caller)
         .with_context(|| {
             format!(
@@ -50,9 +50,9 @@ where
 {
     instance
         .get_export(&mut store, name)
-        .with_context(|| format!("could not find export {:?}", name))?
+        .with_context(|| format!("could not find export {name:?}"))?
         .into_func()
-        .with_context(|| format!("export {:?} is not a function", name))?
+        .with_context(|| format!("export {name:?} is not a function"))?
         .typed(&mut store)
         .with_context(|| {
             format!(

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -109,7 +109,7 @@ where
         let (name, builtin) = self
             .builtins
             .get(&builtin_id)
-            .with_context(|| format!("unknown builtin id {}", builtin_id))?;
+            .with_context(|| format!("unknown builtin id {builtin_id}"))?;
 
         let span = tracing::info_span!("builtin", %name);
         let _enter = span.enter();
@@ -529,7 +529,7 @@ impl<C> Policy<C> {
             .runtime
             .entrypoints
             .get(entrypoint)
-            .with_context(|| format!("could not find entrypoint {}", entrypoint))?;
+            .with_context(|| format!("could not find entrypoint {entrypoint}"))?;
 
         self.loaded_builtins
             .get()


### PR DESCRIPTION
- Fix clippy warnings introduced in Rust 1.66.0
- ci: Pin the clippy version
