### PR TITLE
Update minimum memlimit for policy.rs

### DIFF
--- a/src/policy.rs
+++ b/src/policy.rs
@@ -228,7 +228,7 @@ impl<C> Runtime<C> {
     where
         C: EvaluationContext,
     {
-        let ty = MemoryType::new(2, None);
+        let ty = MemoryType::new(3, None);
         let memory = Memory::new_async(&mut store, ty).await?;
 
         // TODO: make the context configurable and reset it on evaluation


### PR DESCRIPTION
Resolves #161.

Able to see the evaluation result now:

`Error: could not find entrypoint hello/world
