### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,5 +8,172 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0](https://github.com/matrix-org/rust-opa-wasm/releases/tag/v0.1.0) - 2024-07-01
 
+### Fixed
+- fix style
+- fix Clippy
+- fix clippy
+- incorporate feedback
+
+### Other
+- Fill in crate metadata
+- Only mention the initial release in the changelog
+- release
+- Setup release workflow
+- Disallow most panics
+- Document most private items
+- Merge pull request [#180](https://github.com/matrix-org/rust-opa-wasm/pull/180) from matrix-org/dependabot/cargo/wasmtime-gte-16-and-lt-23
+- Tweak some minimal dependencies versions so that it builds with -Zminimal-versions
+- Bump the MSRV to 1.76
+- Update the README to use the reexported wasmtime
+- Make the min wasmtime version 22, add the `fast` feature
+- Re-export wasmtime
+- Make it work with wasmtime 22
+- *(deps)* update wasmtime requirement from >=16, <21 to >=16, <23
+- Merge pull request [#181](https://github.com/matrix-org/rust-opa-wasm/pull/181) from matrix-org/quenting/clippy-1.79
+- Bump clippy to 1.79
+- set the codecov token in the workflow file
+- *(deps)* bump codecov/codecov-action from 3 to 4
+- Merge pull request [#170](https://github.com/matrix-org/rust-opa-wasm/pull/170) from matrix-org/dependabot/cargo/chrono-tz-gte-0.6-and-lt-0.10.0
+- *(deps)* update wasmtime requirement from >=16, <20 to >=16, <21
+- Merge pull request [#168](https://github.com/matrix-org/rust-opa-wasm/pull/168) from matrix-org/dependabot/cargo/base64-0.22
+- *(deps)* update wasmtime requirement from >=16, <19 to >=16, <20
+- Merge pull request [#166](https://github.com/matrix-org/rust-opa-wasm/pull/166) from matrix-org/dependabot/cargo/sprintf-0.2
+- *(deps)* update wasmtime requirement from >=16, <18 to >=16, <19
+- Bump MSRV and minimal wasmtime version
+- run cargo-test with --locked in minimal-features
+- Bump clippy to 1.75
+- *(deps)* update wasmtime requirement from >=8, <16 to >=8, <18
+- *(deps)* update wasmtime requirement from >=8, <15 to >=8, <16
+- *(deps)* update wasmtime requirement from 13 to 14
+- Merge pull request [#160](https://github.com/matrix-org/rust-opa-wasm/pull/160) from matrix-org/quenting/relax-wasmtime
+- Relax wasmtime requirement
+- Merge pull request [#156](https://github.com/matrix-org/rust-opa-wasm/pull/156) from matrix-org/dependabot/cargo/wasmtime-13
+- Bump MSRV to 1.70.0
+- *(deps)* update wasmtime requirement from 12 to 13
+- Pin chrono to a later version to avoid panics
+- *(deps)* bump actions/checkout from 3 to 4
+- Upgrade clippy in CI to 1.72.0 & replace potential panics with results
+- *(deps)* update wasmtime requirement from 11 to 12
+- Fix tests on old versions of chrono
+- Disable unsued default features in some dependencies
+- *(deps)* update wasmtime requirement from 10 to 11
+- *(deps)* update wasmtime requirement from 9 to 10
+- Merge pull request [#145](https://github.com/matrix-org/rust-opa-wasm/pull/145) from matrix-org/dependabot/cargo/async-compression-0.4
+- *(deps)* update wasmtime requirement from 8 to 9
+- *(deps)* update wasmtime requirement from 7 to 8
+- Bump Rust dependencies
+- Bump the MSRV to 1.66.0 and Clippy to 1.67.1
+- Bump dependencies and fix clippy warnings
+- *(deps)* update wasmtime requirement from >=3, <6 to >=3, <7
+- *(deps)* update wasmtime requirement from >=3, <5 to >=3, <6
+- *(deps)* update base64 requirement from >=0.5,<0.14 to >=0.20, <0.21
+- Merge pull request [#132](https://github.com/matrix-org/rust-opa-wasm/pull/132) from matrix-org/dependabot/cargo/json-patch-0.3.0
+- *(deps)* update json-patch requirement from 0.2.3 to 0.3.0
+- Pin the clippy version
+- Fix clippy warnings introduced in Rust 1.66.0
+- Remove unused snapshot
+- Fix building with minimal versions
+- Add a mockable clock in the evaluation context
+- Simplify time builtins parameters
+- review changes
+- implement time
+- Merge pull request [#130](https://github.com/matrix-org/rust-opa-wasm/pull/130) from matrix-org/dependabot/cargo/wasmtime-gte-0.40.0-and-lt-4
+- Use anyhow::Error for builtin errors instead of Trap
+- *(deps)* update wasmtime requirement <4
+- Further reduce the dependencies in the tree
+- Bump open-policy-agent/setup-opa
+- Fix dependabot config
+- Lower the minimal versions of all dependencies & rework CI ([#127](https://github.com/matrix-org/rust-opa-wasm/pull/127))
+- *(deps)* bump tracing-forest from 0.1.4 to 0.1.5
+- Merge pull request [#123](https://github.com/matrix-org/rust-opa-wasm/pull/123) from matrix-org/dependabot/cargo/serde-1.0.147
+- *(deps)* bump serde_yaml from 0.9.13 to 0.9.14
+- *(deps)* bump anyhow from 1.0.65 to 1.0.66
+- Merge pull request [#119](https://github.com/matrix-org/rust-opa-wasm/pull/119) from matrix-org/dependabot/cargo/base64-0.13.1
+- Merge pull request [#121](https://github.com/matrix-org/rust-opa-wasm/pull/121) from matrix-org/dependabot/cargo/clap-4.0.18
+- *(deps)* bump clap from 4.0.17 to 4.0.18
+- Merge pull request [#116](https://github.com/matrix-org/rust-opa-wasm/pull/116) from matrix-org/dependabot/cargo/futures-util-0.3.25
+- *(deps)* bump serde_json from 1.0.86 to 1.0.87
+- *(deps)* bump clap from 4.0.16 to 4.0.17
+- Merge branch 'main' into dependabot/github_actions/actions/cache-3.0.11
+- Bump all dependencies
+- Merge pull request [#96](https://github.com/matrix-org/rust-opa-wasm/pull/96) from matrix-org/dependabot/cargo/serde_yaml-0.9.13
+- Bump serde_yaml from 0.9.12 to 0.9.13
+- Bump tokio from 1.21.0 to 1.21.1
+- Merge pull request [#93](https://github.com/matrix-org/rust-opa-wasm/pull/93) from matrix-org/dependabot/cargo/anyhow-1.0.65
+- Merge pull request [#92](https://github.com/matrix-org/rust-opa-wasm/pull/92) from matrix-org/dependabot/cargo/serde_yaml-0.9.12
+- Merge pull request [#91](https://github.com/matrix-org/rust-opa-wasm/pull/91) from matrix-org/dependabot/cargo/clap-3.2.21
+- Bump thiserror from 1.0.34 to 1.0.35
+- Bump sha1 from 0.10.2 to 0.10.4
+- Merge pull request [#88](https://github.com/matrix-org/rust-opa-wasm/pull/88) from matrix-org/dependabot/cargo/sha2-0.10.5
+- Merge pull request [#87](https://github.com/matrix-org/rust-opa-wasm/pull/87) from matrix-org/dependabot/cargo/serde_yaml-0.9.11
+- Merge pull request [#86](https://github.com/matrix-org/rust-opa-wasm/pull/86) from matrix-org/dependabot/cargo/md-5-0.10.4
+- Merge pull request [#85](https://github.com/matrix-org/rust-opa-wasm/pull/85) from matrix-org/dependabot/cargo/anyhow-1.0.64
+- Bump anyhow from 1.0.63 to 1.0.64
+- Merge pull request [#83](https://github.com/matrix-org/rust-opa-wasm/pull/83) from matrix-org/dependabot/cargo/clap-3.2.20
+- Bump clap from 3.2.19 to 3.2.20
+- Bump wasmtime from 0.40.0 to 0.40.1
+- Merge pull request [#78](https://github.com/matrix-org/rust-opa-wasm/pull/78) from matrix-org/dependabot/cargo/thiserror-1.0.33
+- Merge pull request [#79](https://github.com/matrix-org/rust-opa-wasm/pull/79) from matrix-org/dependabot/cargo/insta-1.19.1
+- Merge pull request [#80](https://github.com/matrix-org/rust-opa-wasm/pull/80) from matrix-org/dependabot/cargo/clap-3.2.19
+- Bump anyhow from 1.0.62 to 1.0.63
+- Merge pull request [#73](https://github.com/matrix-org/rust-opa-wasm/pull/73) from matrix-org/dependabot/cargo/futures-util-0.3.24
+- Merge pull request [#72](https://github.com/matrix-org/rust-opa-wasm/pull/72) from matrix-org/dependabot/cargo/wasmtime-0.40.0
+- Merge pull request [#74](https://github.com/matrix-org/rust-opa-wasm/pull/74) from matrix-org/dependabot/cargo/md-5-0.10.2
+- Bump sha2 from 0.10.2 to 0.10.3
+- Bump serde from 1.0.143 to 1.0.144
+- Merge pull request [#69](https://github.com/matrix-org/rust-opa-wasm/pull/69) from matrix-org/dependabot/cargo/insta-1.19.0
+- Merge pull request [#71](https://github.com/matrix-org/rust-opa-wasm/pull/71) from matrix-org/dependabot/cargo/serde_yaml-0.9.10
+- Merge pull request [#68](https://github.com/matrix-org/rust-opa-wasm/pull/68) from matrix-org/dependabot/cargo/serde_json-1.0.85
+- Bump serde_json from 1.0.83 to 1.0.85
+- Merge pull request [#59](https://github.com/matrix-org/rust-opa-wasm/pull/59) from matrix-org/dependabot/cargo/insta-1.18.2
+- Enable the `yaml` feature in `insta`
+- Bump insta from 1.17.1 to 1.18.2
+- Merge pull request [#65](https://github.com/matrix-org/rust-opa-wasm/pull/65) from matrix-org/dependabot/cargo/futures-util-0.3.23
+- Merge pull request [#66](https://github.com/matrix-org/rust-opa-wasm/pull/66) from matrix-org/dependabot/cargo/serde_yaml-0.9.9
+- Merge pull request [#56](https://github.com/matrix-org/rust-opa-wasm/pull/56) from matrix-org/dependabot/cargo/serde-1.0.143
+- Bump clap from 3.2.16 to 3.2.17
+- Merge pull request [#58](https://github.com/matrix-org/rust-opa-wasm/pull/58) from matrix-org/dependabot/github_actions/actions/cache-3.0.7
+- Merge pull request [#60](https://github.com/matrix-org/rust-opa-wasm/pull/60) from matrix-org/dependabot/cargo/anyhow-1.0.61
+- Bump camino from 1.0.9 to 1.1.1
+- Bump actions/cache from 3.0.5 to 3.0.6
+- Merge pull request [#48](https://github.com/matrix-org/rust-opa-wasm/pull/48) from matrix-org/dependabot/cargo/serde_yaml-0.9.4
+- Merge branch 'main' into quenting/evaluation-context
+- Bump serde_json from 1.0.82 to 1.0.83
+- Bump serde from 1.0.141 to 1.0.142
+- Merge pull request [#49](https://github.com/matrix-org/rust-opa-wasm/pull/49) from matrix-org/dependabot/cargo/thiserror-1.0.32
+- Merge pull request [#51](https://github.com/matrix-org/rust-opa-wasm/pull/51) from matrix-org/dependabot/cargo/semver-1.0.13
+- Merge pull request [#39](https://github.com/matrix-org/rust-opa-wasm/pull/39) from matrix-org/dependabot/cargo/serde-1.0.141
+- Bump serde from 1.0.140 to 1.0.141
+- add feature yaml-builtins
+- implement yaml
+- Merge pull request [#30](https://github.com/matrix-org/rust-opa-wasm/pull/30) from jondot/bif-units
+- Update src/builtins/impls/units.rs
+- Update src/builtins/impls/units.rs
+- Update Cargo.toml
+- Update Cargo.toml
+- this will be too many lines by design
+- feature config
+- implement units
+- clippy
+- reformat toml, remove unneeded fixtures, update test
+- install and build
+- build bundles
+- add license headers
+- Update test and uuid impl
+- merging
+- feedback changes
+- Update tests/smoke_test.rs
+- Update tests/smoke_test.rs
+- sketch test infra + implement uuid
+- Bump MSRV (because cranelift-codegen requires 1.59)
+- Lower MSRV
+- impl Debug for {Runtime,Policy}
+- s/endpoint/entrypoint
+- Avoid unnecessary allocations and conversions during builtins calls
+- Implement printf
+- initial commit
+
+## [0.1.0](https://github.com/matrix-org/rust-opa-wasm/releases/tag/v0.1.0) - 2024-07-01
+
 ### Added
 - Initial release


### PR DESCRIPTION
## 🤖 New release
* `opa-wasm`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).