### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/matrix-org/rust-opa-wasm/compare/v0.1.0...v0.1.1) - 2024-10-07
+
+### Other
+
+- *(ci)* bump clippy in CI to 1.81.0
+- *(deps)* update wasmtime requirement from >=22, <23 to >=22, <24
+
 ## [0.1.0](https://github.com/matrix-org/rust-opa-wasm/releases/tag/v0.1.0) - 2024-07-01
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opa-wasm"
-version = "0.1.0"
+version = "0.1.1"
 description = "A crate to use OPA policies compiled to WASM."
 repository = "https://github.com/matrix-org/rust-opa-wasm"
 rust-version = "1.76"


### PR DESCRIPTION
## 🤖 New release
* `opa-wasm`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/matrix-org/rust-opa-wasm/compare/v0.1.0...v0.1.1) - 2024-10-07

### Other

- *(ci)* bump clippy in CI to 1.81.0
- *(deps)* update wasmtime requirement from >=22, <23 to >=22, <24
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).