### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/matrix-org/rust-opa-wasm/compare/v0.1.2...v0.1.3) - 2024-11-21
+
+### Other
+
+- *(deps)* update wasmtime requirement from >=22, <27 to >=22, <28
+- *(deps)* bump codecov/codecov-action from 4 to 5
+
 ## [0.1.2](https://github.com/matrix-org/rust-opa-wasm/compare/v0.1.1...v0.1.2) - 2024-11-12
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opa-wasm"
-version = "0.1.2"
+version = "0.1.3"
 description = "A crate to use OPA policies compiled to WASM."
 repository = "https://github.com/matrix-org/rust-opa-wasm"
 rust-version = "1.76"


### PR DESCRIPTION
## 🤖 New release
* `opa-wasm`: 0.1.2 -> 0.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/matrix-org/rust-opa-wasm/compare/v0.1.2...v0.1.3) - 2024-11-21

### Other

- *(deps)* update wasmtime requirement from >=22, <27 to >=22, <28
- *(deps)* bump codecov/codecov-action from 4 to 5
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).