### PR TITLE
chore: release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/matrix-org/rust-opa-wasm/compare/v0.1.5...v0.1.6) - 2025-05-20
+
+### Other
+
+- *(deps)* update wasmtime requirement from >=22, <32 to >=22, <34
+
 ## [0.1.5](https://github.com/matrix-org/rust-opa-wasm/compare/v0.1.4...v0.1.5) - 2025-04-06
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opa-wasm"
-version = "0.1.5"
+version = "0.1.6"
 description = "A crate to use OPA policies compiled to WASM."
 repository = "https://github.com/matrix-org/rust-opa-wasm"
 rust-version = "1.76"


### PR DESCRIPTION



## 🤖 New release

* `opa-wasm`: 0.1.5 -> 0.1.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.6](https://github.com/matrix-org/rust-opa-wasm/compare/v0.1.5...v0.1.6) - 2025-05-20

### Other

- *(deps)* update wasmtime requirement from >=22, <32 to >=22, <34
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).