### PR TITLE
chore: release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.7](https://github.com/matrix-org/rust-opa-wasm/compare/v0.1.6...v0.1.7) - 2025-07-30
+
+### Other
+
+- *(deps)* update wasmtime requirement from >=22, <35 to >=22, <36
+- fix clippy warnings
+- bump rust/clippy to 1.88.0
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(deps)* update wasmtime requirement from >=22, <35 to >=22, <36
 - fix clippy warnings
 - bump rust/clippy to 1.88.0
-# Changelog
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
 
 ## [0.1.6](https://github.com/matrix-org/rust-opa-wasm/compare/v0.1.5...v0.1.6) - 2025-07-21
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opa-wasm"
-version = "0.1.6"
+version = "0.1.7"
 description = "A crate to use OPA policies compiled to WASM."
 repository = "https://github.com/matrix-org/rust-opa-wasm"
 rust-version = "1.76"


### PR DESCRIPTION



## 🤖 New release

* `opa-wasm`: 0.1.6 -> 0.1.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).