### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/matrix-org/rust-opa-wasm/compare/v0.1.9...v0.2.0) - 2026-04-10
+
+### Other
+
+- bump MSRV to 1.91
+- *(deps)* [**breaking**] require wasmtime >=42, <44
+- *(deps)* update wasmtime requirement from >=22, <42 to >=22, <44
+- *(deps)* update json-patch requirement from >=0.2.3, <4.1.0 to >=0.2.3, <4.2.0 ([#234](https://github.com/matrix-org/rust-opa-wasm/pull/234))
+- *(deps)* bump codecov/codecov-action from 5 to 6 ([#251](https://github.com/matrix-org/rust-opa-wasm/pull/251))
+- *(deps)* bump codecov/codecov-action from 5 to 6
+
 ## [0.1.9](https://github.com/matrix-org/rust-opa-wasm/compare/v0.1.8...v0.1.9) - 2025-12-28
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opa-wasm"
-version = "0.1.9"
+version = "0.2.0"
 description = "A crate to use OPA policies compiled to WASM."
 repository = "https://github.com/matrix-org/rust-opa-wasm"
 rust-version = "1.91"


### PR DESCRIPTION



## 🤖 New release

* `opa-wasm`: 0.1.9 -> 0.2.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/matrix-org/rust-opa-wasm/compare/v0.1.9...v0.2.0) - 2026-04-10

### Other

- bump MSRV to 1.91
- *(deps)* [**breaking**] require wasmtime >=42, <44
- *(deps)* update wasmtime requirement from >=22, <42 to >=22, <44
- *(deps)* update json-patch requirement from >=0.2.3, <4.1.0 to >=0.2.3, <4.2.0 ([#234](https://github.com/matrix-org/rust-opa-wasm/pull/234))
- *(deps)* bump codecov/codecov-action from 5 to 6 ([#251](https://github.com/matrix-org/rust-opa-wasm/pull/251))
- *(deps)* bump codecov/codecov-action from 5 to 6
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).