### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/matrix-org/rust-opa-wasm/compare/v0.2.0...v0.2.1) - 2026-05-07
+
+### Fixed
+
+- *(policy)* read declared memory minimum from imported module
+
+### Other
+
+- Apply suggestions from code review
+
 ## [0.2.0](https://github.com/matrix-org/rust-opa-wasm/compare/v0.1.9...v0.2.0) - 2026-04-10
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opa-wasm"
-version = "0.2.0"
+version = "0.2.1"
 description = "A crate to use OPA policies compiled to WASM."
 repository = "https://github.com/matrix-org/rust-opa-wasm"
 rust-version = "1.91"


### PR DESCRIPTION



## 🤖 New release

* `opa-wasm`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/matrix-org/rust-opa-wasm/compare/v0.2.0...v0.2.1) - 2026-05-07

### Fixed

- *(policy)* read declared memory minimum from imported module

### Other

- Apply suggestions from code review
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).