### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/matrix-org/rust-opa-wasm/compare/v0.3.1...v0.3.2) - 2026-08-04
+
+### Other
+
+- *(deps)* update base64 requirement from 0.22 to 0.23 ([#271](https://github.com/matrix-org/rust-opa-wasm/pull/271))
+- *(deps)* update base64 requirement from 0.22 to 0.23
+
 ## [0.3.1](https://github.com/matrix-org/rust-opa-wasm/compare/v0.3.0...v0.3.1) - 2026-07-08
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opa-wasm"
-version = "0.3.1"
+version = "0.3.2"
 description = "A crate to use OPA policies compiled to WASM."
 repository = "https://github.com/matrix-org/rust-opa-wasm"
 rust-version = "1.91"


### PR DESCRIPTION



## 🤖 New release

* `opa-wasm`: 0.3.1 -> 0.3.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.2](https://github.com/matrix-org/rust-opa-wasm/compare/v0.3.1...v0.3.2) - 2026-08-04

### Other

- *(deps)* update base64 requirement from 0.22 to 0.23 ([#271](https://github.com/matrix-org/rust-opa-wasm/pull/271))
- *(deps)* update base64 requirement from 0.22 to 0.23
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).